### PR TITLE
SMILE-1530: bruker AuthorizeBackendClient.send()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,15 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36'
     implementation group: 'com.github.bibsysdev', name: 'nva-datamodel-java', version: '0.15.1'
-    implementation group: 'com.github.bibsysdev', name: 'identifiers', version: '1.20.22'
-    implementation group: 'com.github.bibsysdev', name: 'core', version: '1.20.22'
-    implementation group: 'com.github.bibsysdev', name: 'json', version: '1.20.22'
-    implementation group: 'com.github.bibsysdev', name: 'apigateway', version: '1.20.22'
+    implementation group: 'com.github.bibsysdev', name: 'identifiers', version: '1.22.0'
+    implementation group: 'com.github.bibsysdev', name: 'auth', version: '1.22.0'
+    implementation group: 'com.github.bibsysdev', name: 'core', version: '1.22.0'
+    implementation group: 'com.github.bibsysdev', name: 'json', version: '1.22.0'
+    implementation group: 'com.github.bibsysdev', name: 'apigateway', version: '1.22.0'
     implementation group: 'com.amazonaws', name: 'aws-lambda-java-core', version: '1.2.1'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.0'
-    testImplementation group: 'com.github.bibsysdev', name: 'nvatestutils', version: '1.20.22'
+    testImplementation group: 'com.github.bibsysdev', name: 'nvatestutils', version: '1.22.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest', version: '2.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.1.0'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.8.2'
@@ -111,5 +112,11 @@ jacocoTestCoverageVerification {
             }
         }
     }
+}
+
+test {
+    environment "BACKEND_CLIENT_ID", "backendClientId"
+    environment "BACKEND_CLIENT_SECRET", "backendClientSecret"
+    environment "COGNITO_URI", "https://notused.org"
 }
 

--- a/src/main/java/no/sikt/oai/OaiProviderHandler.java
+++ b/src/main/java/no/sikt/oai/OaiProviderHandler.java
@@ -4,7 +4,6 @@ import static com.google.common.net.MediaType.APPLICATION_XML_UTF_8;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.MediaType;
 import java.net.HttpURLConnection;
-import java.net.http.HttpClient;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -18,6 +17,7 @@ import no.sikt.oai.data.RecordsList;
 import no.sikt.oai.exception.InternalOaiException;
 import no.sikt.oai.exception.OaiException;
 import no.sikt.oai.service.DataProvider;
+import no.unit.nva.auth.AuthorizedBackendClient;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
@@ -37,10 +37,10 @@ public class OaiProviderHandler extends ApiGatewayHandler<Void, String> {
 
     @JacocoGenerated
     public OaiProviderHandler() {
-        this(new Environment(), HttpClient.newBuilder().build());
+        this(new Environment(), AuthorizedBackendClient.prepareWithBackendCredentials());
     }
 
-    public OaiProviderHandler(Environment environment, HttpClient client) {
+    public OaiProviderHandler(Environment environment, AuthorizedBackendClient client) {
         super(Void.class, environment);
         initAdapter();
         this.dataProvider = new DataProvider(client, adapter);

--- a/src/main/java/no/sikt/oai/service/DataProvider.java
+++ b/src/main/java/no/sikt/oai/service/DataProvider.java
@@ -8,39 +8,40 @@ import static no.sikt.oai.OaiConstants.UNKNOWN_IDENTIFIER;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import java.net.HttpURLConnection;
-import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import no.sikt.oai.OaiConstants;
 import no.sikt.oai.adapter.Adapter;
 import no.sikt.oai.exception.InternalOaiException;
 import no.sikt.oai.exception.OaiException;
+import no.unit.nva.auth.AuthorizedBackendClient;
 import nva.commons.core.JacocoGenerated;
 import org.apache.http.HttpStatus;
 
 public class DataProvider {
 
-    private final transient HttpClient client;
+    private final transient AuthorizedBackendClient client;
     private final transient Adapter adapter;
 
-    public DataProvider(HttpClient client, Adapter adapter) {
+    public DataProvider(AuthorizedBackendClient client, Adapter adapter) {
         this.client = client;
         this.adapter = adapter;
     }
 
     @JacocoGenerated
     public DataProvider(Adapter adapter) {
-        this(HttpClient.newBuilder().build(), adapter);
+        this(AuthorizedBackendClient.prepareWithBackendCredentials(), adapter);
     }
 
     public String getSetsList() throws OaiException, InternalOaiException {
         HttpResponse<String> response;
         try {
-            HttpRequest httpRequest = HttpRequest.newBuilder()
+            Builder httpRequest = HttpRequest.newBuilder()
                     .uri(adapter.getSetsUri())
                     .header(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
-                    .GET()
-                    .build();
+                    .GET();
+//                    .build();
             response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
         } catch (Exception e) {
             throw new InternalOaiException(e, HttpURLConnection.HTTP_UNAVAILABLE);
@@ -54,12 +55,11 @@ public class DataProvider {
     public String getRecord(String identifier) throws OaiException, InternalOaiException {
         HttpResponse<String> response;
         try {
-            HttpRequest httpRequest = HttpRequest.newBuilder()
+            Builder builder = HttpRequest.newBuilder()
                     .uri(adapter.getRecordUri(identifier))
                     .header(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
-                    .GET()
-                    .build();
-            response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+                    .GET();
+            response = client.send(builder, HttpResponse.BodyHandlers.ofString());
         } catch (Exception e) {
             throw new InternalOaiException(e, HttpURLConnection.HTTP_UNAVAILABLE);
         }
@@ -73,12 +73,11 @@ public class DataProvider {
             throws OaiException, InternalOaiException {
         HttpResponse<String> response;
         try {
-            HttpRequest httpRequest = HttpRequest.newBuilder()
+            Builder builder = HttpRequest.newBuilder()
                     .uri(adapter.getRecordsListUri(from, until, setSpec, startPosition))
                     .header(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
-                    .GET()
-                    .build();
-            response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+                    .GET();
+            response = client.send(builder, HttpResponse.BodyHandlers.ofString());
         } catch (Exception e) {
             throw new InternalOaiException(e, HttpURLConnection.HTTP_UNAVAILABLE);
         }

--- a/src/main/java/no/sikt/oai/service/DataProvider.java
+++ b/src/main/java/no/sikt/oai/service/DataProvider.java
@@ -37,12 +37,11 @@ public class DataProvider {
     public String getSetsList() throws OaiException, InternalOaiException {
         HttpResponse<String> response;
         try {
-            Builder httpRequest = HttpRequest.newBuilder()
+            Builder builder = HttpRequest.newBuilder()
                     .uri(adapter.getSetsUri())
                     .header(CONTENT_TYPE, APPLICATION_JSON.getMimeType())
                     .GET();
-//                    .build();
-            response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+            response = client.send(builder, HttpResponse.BodyHandlers.ofString());
         } catch (Exception e) {
             throw new InternalOaiException(e, HttpURLConnection.HTTP_UNAVAILABLE);
         }

--- a/src/test/java/no/sikt/oai/OaiProviderHandlerTest.java
+++ b/src/test/java/no/sikt/oai/OaiProviderHandlerTest.java
@@ -31,7 +31,6 @@ import static no.sikt.oai.OaiConstants.UNKNOWN_SET_NAME;
 import static no.sikt.oai.OaiConstants.VERB_IS_MISSING;
 import static no.sikt.oai.RestApiConfig.restServiceObjectMapper;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.apigateway.ApiGatewayHandler.ALLOWED_ORIGIN_ENV;
 import static nva.commons.apigateway.RestRequestHandler.EMPTY_STRING;
@@ -47,15 +46,20 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
+import no.unit.nva.auth.AuthorizedBackendClient;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import no.unit.nva.stubs.WiremockHttpClient;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.core.Environment;
@@ -82,7 +86,7 @@ public class OaiProviderHandlerTest {
     public static final String METADATA_TAG = "<metadata>";
     public static final String UIO_CUSTUMER_ID = "https://api.dev.nva.aws.unit"
                                                  + ".no/customer/1bd2e3f7-a570-442a-b444-cb02e6cc70e4";
-    private final HttpClient httpClient = WiremockHttpClient.create();
+    private AuthorizedBackendClient authorizedBackendClient;
     private OaiProviderHandler handler;
     private Environment environment;
     private Context context;
@@ -95,6 +99,14 @@ public class OaiProviderHandlerTest {
         environment = mock(Environment.class);
         when(environment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
         when(environment.readEnv(CLIENT_NAME_ENV)).thenReturn(adapter);
+        final HttpClient httpClient = WiremockHttpClient.create();
+        authorizedBackendClient = new AuthorizedBackendClient(null, null, null) {
+            @Override
+            public <T> HttpResponse<T> send(HttpRequest.Builder request, BodyHandler<T> responseBodyHandler)
+                throws IOException, InterruptedException {
+                return httpClient.send(request.build(), responseBodyHandler);
+            }
+        };
         startWiremockServer(adapter);
         when(environment.readEnv(SETS_URI_ENV)).thenReturn(serverUriSets.toString());
         when(environment.readEnv(RECORD_URI_ENV)).thenReturn(serverUriRecord.toString());
@@ -103,7 +115,7 @@ public class OaiProviderHandlerTest {
         mockSetsResponse(adapter);
         mockRecordResponse(adapter);
         mockRecordsResponse(adapter);
-        handler = new OaiProviderHandler(environment, httpClient);
+        handler = new OaiProviderHandler(environment, authorizedBackendClient);
     }
 
     @AfterEach
@@ -220,7 +232,7 @@ public class OaiProviderHandlerTest {
     public void shouldReturnExceptionWhenGetRecordWhenComunicationCrashes() throws IOException {
         init(CLIENT_TYPE_DLR);
         when(environment.readEnv(RECORD_URI_ENV)).thenReturn(FAULTY_JSON);
-        handler = new OaiProviderHandler(environment, httpClient);
+        handler = new OaiProviderHandler(environment, authorizedBackendClient);
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put(ValidParameterKey.VERB.key, Verb.GetRecord.name());
         queryParameters.put(ValidParameterKey.IDENTIFIER.key, REAL_OAI_IDENTIFIER_DLR);
@@ -455,7 +467,7 @@ public class OaiProviderHandlerTest {
         throws IOException {
         init(CLIENT_TYPE_DLR);
         when(environment.readEnv(SETS_URI_ENV)).thenReturn(FAULTY_JSON);
-        handler = new OaiProviderHandler(environment, httpClient);
+        handler = new OaiProviderHandler(environment, authorizedBackendClient);
         var output = new ByteArrayOutputStream();
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put(ValidParameterKey.VERB.key, Verb.ListSets.name());
@@ -586,7 +598,7 @@ public class OaiProviderHandlerTest {
     public void shouldReturnExceptionWhenAskedForListRecordsAndServerCommunicationFails() throws IOException {
         init(CLIENT_TYPE_DLR);
         when(environment.readEnv(RECORDS_URI_ENV)).thenReturn(FAULTY_JSON);
-        handler = new OaiProviderHandler(environment, httpClient);
+        handler = new OaiProviderHandler(environment, authorizedBackendClient);
         Map<String, String> queryParameters = new HashMap<>();
         queryParameters.put(ValidParameterKey.VERB.key, Verb.ListRecords.name());
         queryParameters.put(ValidParameterKey.METADATAPREFIX.key, MetadataFormat.OAI_DATACITE.name());
@@ -707,7 +719,8 @@ public class OaiProviderHandlerTest {
         when(environment.readEnv(ALLOWED_ORIGIN_ENV)).thenReturn("*");
         when(environment.readEnv(CLIENT_NAME_ENV)).thenReturn(UNKNOWN_CLIENT_NAME);
         context = mock(Context.class);
-        assertThrows(RuntimeException.class, () -> handler = new OaiProviderHandler(environment, httpClient));
+        assertThrows(RuntimeException.class, () -> handler = new OaiProviderHandler(environment,
+                                                                                    authorizedBackendClient));
     }
 
     @Test

--- a/src/test/java/no/sikt/oai/WiremockHttpClient.java
+++ b/src/test/java/no/sikt/oai/WiremockHttpClient.java
@@ -1,5 +1,6 @@
 package no.sikt.oai;
 
+import no.unit.nva.auth.AuthorizedBackendClient;
 import org.junit.jupiter.api.Assertions;
 
 import javax.net.ssl.SSLContext;
@@ -15,15 +16,16 @@ import java.security.cert.X509Certificate;
 public final class WiremockHttpClient {
 
     public static final String TEST_CONFIGURATION_TRUST_MANAGER_FAILURE =
-            "Failed to configure the trust everything rule for the http client, which is required to connect to "
-                    + "wiremock server and local signed SSL certificate for now.";
+        "Failed to configure the trust everything rule for the http client, which is required to connect to "
+        + "wiremock server and local signed SSL certificate for now.";
 
     private WiremockHttpClient() {
 
     }
 
-    public static HttpClient create() {
-        return HttpClient.newBuilder().sslContext(createInsecureSslContextTrustingEverything()).build();
+    public static AuthorizedBackendClient create() {
+        return AuthorizedBackendClient.prepareWithBackendCredentials(
+            HttpClient.newBuilder().sslContext(createInsecureSslContextTrustingEverything()).build());
     }
 
     @SuppressWarnings("PMD.AvoidPrintStackTrace")
@@ -31,7 +33,7 @@ public final class WiremockHttpClient {
         try {
             var insecureSslContext = SSLContext.getInstance("SSL");
             insecureSslContext.init(null, new X509ExtendedTrustManager[]{createTrustEverythingManager()},
-                    new java.security.SecureRandom());
+                                    new java.security.SecureRandom());
             return insecureSslContext;
         } catch (KeyManagementException | NoSuchAlgorithmException e) {
             e.printStackTrace();
@@ -46,12 +48,12 @@ public final class WiremockHttpClient {
         return new X509ExtendedTrustManager() {
             @Override
             public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
-                    throws CertificateException {
+                throws CertificateException {
             }
 
             @Override
             public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
-                    throws CertificateException {
+                throws CertificateException {
             }
 
             @Override
@@ -60,12 +62,12 @@ public final class WiremockHttpClient {
 
             @Override
             public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
-                    throws CertificateException {
+                throws CertificateException {
             }
 
             @Override
             public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
-                    throws CertificateException {
+                throws CertificateException {
             }
 
             @Override


### PR DESCRIPTION
Her bruker jeg nå den nye Orestis-style authorization for NVA backend i DataProvider.
Vil det fungere i DLR sammenheng, eller må vi har et eget DataProvider der?
Vi kan bare rulle det ut på SANDBOX og ser hva skjer.